### PR TITLE
Don't require an options object to use readElectronVersion

### DIFF
--- a/src/readelectronversion.js
+++ b/src/readelectronversion.js
@@ -10,7 +10,7 @@ const path = require('path')
  * The content of the version file post-4.0 is just the version.
  * Both of these are acceptable to the `semver` module.
  */
-module.exports = function readElectronVersion (options) {
-  return fs.readFile(path.resolve(options.src, 'version'))
+module.exports = function readElectronVersion (appDir) {
+  return fs.readFile(path.resolve(appDir, 'version'))
     .then(tag => tag.toString().trim())
 }

--- a/test/readelectronversion.js
+++ b/test/readelectronversion.js
@@ -1,9 +1,10 @@
 'use strict'
 
+const path = require('path')
 const readElectronVersion = require('../src/readelectronversion')
 const test = require('ava')
 
 test('readElectronVersion', t => {
-  return readElectronVersion({ src: 'test/fixtures' })
+  return readElectronVersion(path.resolve(__dirname, 'fixtures'))
     .then(version => t.is(version, 'v3.0.11'))
 })


### PR DESCRIPTION
I found this while trying to port `electron-installer-snap` over to use `electron-installer-common`.

This is a breaking change to the API, and I'm going to release 0.3.0 after this is merged.