### PR TITLE
Extract getTrashDepends from getDepends

### DIFF
--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -18,16 +18,18 @@ function getGTKDepends (version, dependencyMap) {
 }
 
 /**
- * Determine the dependencies for the `shell.moveItemToTrash` API, based on the
+ * Determine the dependencies for the `shell.moveItemToTrash` Electron API, based on the
  * Electron version in use.
+ *
+ * @return {string[]} an ordered list of dependencies that are OR'd together by the installer module.
  */
 function getTrashDepends (version, dependencyMap) {
   if (semver.lt(version, '1.4.1')) {
-    return dependencyMap.gvfs
+    return [dependencyMap.gvfs]
   } else if (semver.lt(version, '1.7.2')) {
-    return `${dependencyMap.kdeCliTools} | ${dependencyMap.kdeRuntime} | ${dependencyMap.trashCli} | ${dependencyMap.gvfs}`
+    return [dependencyMap.kdeCliTools, dependencyMap.kdeRuntime, dependencyMap.trashCli, dependencyMap.gvfs]
   } else {
-    return `${dependencyMap.kdeCliTools} | ${dependencyMap.kdeRuntime} | ${dependencyMap.trashCli} | ${dependencyMap.glib2} | ${dependencyMap.gvfs}`
+    return [dependencyMap.kdeCliTools, dependencyMap.kdeRuntime, dependencyMap.trashCli, dependencyMap.glib2, dependencyMap.gvfs]
   }
 }
 
@@ -44,7 +46,6 @@ module.exports = {
    */
   getDepends: function getDepends (version, dependencyMap) {
     return [
-      getTrashDepends(version, dependencyMap),
       getGTKDepends(version, dependencyMap),
       dependencyMap.notify,
       dependencyMap.nss,

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -43,23 +43,23 @@ test('getGTKDepends: returns GTK3 as of 2.0', t => {
 
 test('getTrashDepends: only depends on gvfs-bin before 1.4.1', t => {
   const trashDepends = dependencies.getTrashDepends('v1.3.0', dependencyMap)
-  t.regex(trashDepends, new RegExp(dependencyMap.gvfs))
-  t.notRegex(trashDepends, new RegExp(dependencyMap.kdeCliTools))
-  t.notRegex(trashDepends, new RegExp(dependencyMap.glib2))
+  t.true(trashDepends.includes(dependencyMap.gvfs))
+  t.false(trashDepends.includes(dependencyMap.kdeCliTools))
+  t.false(trashDepends.includes(dependencyMap.glib2))
 })
 
 test('getTrashDepends: depends on KDE tools between 1.4.1 and 1.7.1', t => {
   const trashDepends = dependencies.getTrashDepends('v1.6.0', dependencyMap)
-  t.regex(trashDepends, new RegExp(dependencyMap.gvfs))
-  t.regex(trashDepends, new RegExp(dependencyMap.kdeCliTools))
-  t.notRegex(trashDepends, new RegExp(dependencyMap.glib2))
+  t.true(trashDepends.includes(dependencyMap.gvfs))
+  t.true(trashDepends.includes(dependencyMap.kdeCliTools))
+  t.false(trashDepends.includes(dependencyMap.glib2))
 })
 
 test('getTrashDepends: depends on glib starting with 1.7.2', t => {
   const trashDepends = dependencies.getTrashDepends('v1.8.2', dependencyMap)
-  t.regex(trashDepends, new RegExp(dependencyMap.gvfs))
-  t.regex(trashDepends, new RegExp(dependencyMap.kdeCliTools))
-  t.regex(trashDepends, new RegExp(dependencyMap.glib2))
+  t.true(trashDepends.includes(dependencyMap.gvfs))
+  t.true(trashDepends.includes(dependencyMap.kdeCliTools))
+  t.true(trashDepends.includes(dependencyMap.glib2))
 })
 
 test('getUUIDDepends: returns nothing pre-4.0', t => {


### PR DESCRIPTION
Its return value used Debian-specific syntax, so it was changed to return a list of values that can be transformed in the installer module.

As a result, installer modules must `.concat()` the transformed value onto the dependency list.

This is required in order for `electron-installer-redhat` to use `getDepends`.

This is a breaking API change.