### PR TITLE
Export only necessary modules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,15 @@
+const dependencies = require('./dependencies')
+const installer = require('./installer')
+const spawn = require('./spawn')
+const replaceScopeName = require('./replacescopename')
+const readElectronVersion = require('./readelectronversion')
+
+module.exports = {
+  common: installer,
+  mergeUserSpecified: dependencies.mergeUserSpecified,
+  getDepends: dependencies.getDepends,
+  getTrashDepends: dependencies.getTrashDepends,
+  readElectronVersion: readElectronVersion,
+  replaceScopeName: replaceScopeName,
+  spawn: spawn
+}

--- a/src/installer.js
+++ b/src/installer.js
@@ -6,7 +6,6 @@ const fs = require('fs-extra')
 const getHomePage = require('./gethomepage')
 const glob = require('glob-promise')
 const path = require('path')
-const spawn = require('./spawn')
 const tmp = require('tmp-promise')
 
 /**
@@ -222,6 +221,5 @@ module.exports = {
         }
       }).catch(wrapError('reading package metadata'))
   },
-  spawn: spawn,
   wrapError: wrapError
 }


### PR DESCRIPTION
This cleans up how we export things to make it easier to import on the modules depending on this.
This will be a breaking change