### PR TITLE
Check that createBinary symlinks to an existing Electron app binary

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,10 +101,16 @@ module.exports = {
     const binDest = path.join(binDir, options.name)
     options.logger(`Symlinking binary from ${binSrc} to ${binDest}`)
 
-    return fs.ensureDir(binDir, '0755')
-      .catch(wrapError('creating binary path'))
-      .then(() => fs.symlink(binSrc, binDest, 'file'))
-      .catch(wrapError('creating binary file'))
+    const bundledBin = path.join(options.src, options.bin)
+
+    return fs.pathExists(bundledBin)
+      .then(exists => {
+        if (!exists) {
+          throw new Error(`could not find the Electron app binary at "${bundledBin}". You may need to set the "bin" option to the correct binary.`)
+        }
+        return fs.ensureDir(binDir, '0755')
+      }).then(() => fs.symlink(binSrc, binDest, 'file'))
+      .catch(wrapError('creating binary symlink'))
   },
   createContents: function createContents (options, dir, functions) {
     options.logger('Creating contents of package')

--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ module.exports = {
     return fs.pathExists(bundledBin)
       .then(exists => {
         if (!exists) {
-          throw new Error(`could not find the Electron app binary at "${bundledBin}". You may need to set the "bin" option to the correct binary.`)
+          throw new Error(`could not find the Electron app binary at "${bundledBin}". You may need to re-bundle the app using Electron Packager's "executableName" option.`)
         }
         return fs.ensureDir(binDir, '0755')
       }).then(() => fs.symlink(binSrc, binDest, 'file'))

--- a/test/installer.js
+++ b/test/installer.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const { createBinary } = require('..')
+const fs = require('fs-extra')
+const path = require('path')
+const test = require('ava')
+const tmp = require('tmp-promise')
+
+test('createBinary creates symlink when bin exists', t => {
+  const options = {
+    bin: 'app-name',
+    logger: log => log,
+    name: 'bundled_app',
+    src: path.join(__dirname, 'fixtures', 'bundled_app')
+  }
+  return tmp.dir({ prefix: 'electron-installer-common-', unsafeCleanup: true })
+    .then(dir => {
+      options.dest = dir.path
+      return createBinary(options, options.dest)
+    }).then(() => fs.lstat(path.join(options.dest, 'usr', 'bin', 'bundled_app')))
+    .then(stats => t.true(stats.isSymbolicLink()))
+})
+
+test('createBinary does not create symlink when bin does not exist', t => {
+  const options = {
+    bin: 'nonexistent',
+    logger: log => log,
+    name: 'bundled_app',
+    src: path.join(__dirname, 'fixtures', 'bundled_app')
+  }
+  return tmp.dir({ prefix: 'electron-installer-common-', unsafeCleanup: true })
+    .then(dir => {
+      return t.throwsAsync(createBinary(options, dir.path), /could not find the Electron app binary/)
+    })
+})


### PR DESCRIPTION
Fixes https://github.com/electron-userland/electron-installer-debian/issues/168 by erroring if the binary symlink is invalid.