### PR TITLE
Re-export public functions not already in src/index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,13 @@
 
 const _ = require('lodash')
 const asar = require('asar')
+const dependencies = require('./dependencies')
 const fs = require('fs-extra')
 const getHomePage = require('./gethomepage')
 const glob = require('glob-promise')
 const path = require('path')
+const readElectronVersion = require('./readelectronversion')
+const replaceScopeName = require('./replacescopename')
 const spawn = require('./spawn')
 const tmp = require('tmp-promise')
 
@@ -195,6 +198,12 @@ module.exports = {
       revision: pkg.revision || '1'
     }
   },
+  getDepends: dependencies.getDepends,
+  getGConfDepends: dependencies.getGConfDepends,
+  getGTKDepends: dependencies.getGTKDepends,
+  getTrashDepends: dependencies.getTrashDepends,
+  getUUIDDepends: dependencies.getUUIDDepends,
+  mergeUserSpecified: dependencies.mergeUserSpecified,
   /**
    * Move the package to the specified destination.
    */
@@ -209,6 +218,7 @@ module.exports = {
         return fs.move(file, dest, { clobber: true })
       }))).catch(wrapError('moving package files'))
   },
+  readElectronVersion: readElectronVersion,
   /**
    * Read `package.json` either from `resources/app.asar` (if the app is packaged)
    * or from `resources/app/package.json` (if it is not).
@@ -228,6 +238,7 @@ module.exports = {
         }
       }).catch(wrapError('reading package metadata'))
   },
+  replaceScopeName: replaceScopeName,
   spawn: spawn,
   wrapError: wrapError
 }


### PR DESCRIPTION
This is basically #5, except that it doesn't move all of the non-export code out of `src/index.js`, and there are no merge conflicts. Tested by changing the code in `-debian`, `-redhat`, and `-snap` to use the re-exported functions.

No breaking changes.

Closes #5.