### PR TITLE
Add sanitize name function & fix default replaceScopeName divider

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const path = require('path')
 const readElectronVersion = require('./readelectronversion')
 const readMetadata = require('./readmetadata')
 const replaceScopeName = require('./replacescopename')
+const sanitizeName = require('./sanitizename')
 const spawn = require('./spawn')
 const tmp = require('tmp-promise')
 
@@ -211,6 +212,7 @@ module.exports = {
   readElectronVersion: readElectronVersion,
   readMeta: readMetadata,
   replaceScopeName: replaceScopeName,
+  sanitizeName: sanitizeName,
   spawn: spawn,
   wrapError: error.wrapError
 }

--- a/src/replacescopename.js
+++ b/src/replacescopename.js
@@ -4,10 +4,10 @@
  * Normalizes a scoped package name for use as an OS package name.
  *
  * @param {?string} [name=''] - the Node package name to normalize
- * @param {?string} [divider='_'] - the character(s) to replace slashes with
+ * @param {?string} [divider='-'] - the character(s) to replace slashes with
  */
 module.exports = function replaceScopeName (name, divider) {
   name = name || ''
-  divider = divider || '_'
+  divider = divider || '-'
   return name.replace(/^@/, '').replace('/', divider)
 }

--- a/src/sanitizename.js
+++ b/src/sanitizename.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const replaceScopeName = require('./replacescopename')
+
+/**
+ * Sanitizes a package name for use as an installer name.
+ *
+ * Includes running `replaceScopeName`.
+ *
+ * @param {string} name - the Node package name to normalize
+ * @param {string} allowedCharacterRange - a `RegExp` range (minus the square brackets) of allowable
+ * characters for the given installer
+ * @param {?string} [replacement='-'] - the character(s) to replace invalid characters with
+ */
+module.exports = function sanitizeName (name, allowedCharacterRange, replacement) {
+  replacement = replacement || '-'
+
+  return replaceScopeName(name, replacement).replace(new RegExp(`[^${allowedCharacterRange}]`, 'g'), replacement)
+}

--- a/test/replacescopename.js
+++ b/test/replacescopename.js
@@ -12,9 +12,9 @@ test('Return same name if not scoped', t => {
 })
 
 test('Scoped name with default divider', t => {
-  t.is(replaceScopeName('@scoped/core'), 'scoped_core')
+  t.is(replaceScopeName('@scoped/core'), 'scoped-core')
 })
 
 test('Scoped name using a custom divider', t => {
-  t.is(replaceScopeName('@scoped/core', '-'), 'scoped-core')
+  t.is(replaceScopeName('@scoped/core', '_'), 'scoped_core')
 })

--- a/test/sanitizename.js
+++ b/test/sanitizename.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const sanitizeName = require('../src/sanitizename')
+const test = require('ava')
+
+test('replaces invalid characters', t => {
+  t.is(sanitizeName('abcd', 'abd'), 'ab-d')
+})
+
+test('replaces invalid characters with custom replacement', t => {
+  t.is(sanitizeName('abcd', 'abd', '@'), 'ab@d')
+})


### PR DESCRIPTION
* The default divider for `replaceScopeName` should be `-`, not `_` (per https://github.com/electron-userland/electron-installer-common/pull/1#discussion_r245060183)
* Adds a `sanitizeName` function (which also calls `replaceScopeName`). Addresses https://github.com/electron-userland/electron-forge/issues/654