### PR TITLE
Retain original backtrace when using wrapError

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -6,10 +6,19 @@ function errorMessage (message, err) {
 
 module.exports = {
   errorMessage: errorMessage,
+  /**
+   * Prepends the error message with the given `message`.
+   *
+   * Designed to be used in a `Promise`'s `catch` method. For example:
+   *
+   * ```javascript
+   * Promise.reject(new Error('My error')).catch(wrapError('with the code'))
+   * ```
+   */
   wrapError: function wrapError (message) {
     return err => {
-      /* istanbul ignore next */
-      throw new Error(errorMessage(message, err))
+      err.message = errorMessage(message, err)
+      throw err
     }
   }
 }

--- a/test/error.js
+++ b/test/error.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const error = require('../src/error')
+const test = require('ava')
+
+test('errorMessage with Error containing message', t => {
+  t.is(error.errorMessage('in a test', new Error('Message')), 'Error in a test: Message')
+})
+
+test('errorMessage with Error sans message', t => {
+  t.is(error.errorMessage('in a test', new Error()), 'Error in a test: Error')
+})
+
+test('wrapError', t => {
+  const promise = Promise.reject(new Error('My error'))
+    .catch(error.wrapError('in a test'))
+  return t.throwsAsync(promise, /Error in a test: My error/)
+})


### PR DESCRIPTION
Without this change, calling `new Error` causes the original backtrace to disappear and makes it more difficult to track down where the exception was thrown.