### PR TITLE
Installer class

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "nyc": "^13.1.0"
+    "nyc": "^13.1.0",
+    "sinon": "^7.2.2"
   },
   "dependencies": {
     "asar": "^0.14.6",

--- a/src/desktop.js
+++ b/src/desktop.js
@@ -10,7 +10,7 @@ module.exports = {
     const dest = path.join(dir, `${baseName}.desktop`)
     debug(`Creating desktop file at ${dest}`)
 
-    return createTemplatedFile(templatePath, dest, options)
+    return createTemplatedFile(templatePath, dest, options, 0o644)
       .catch(wrapError('creating desktop file'))
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,153 +1,21 @@
 'use strict'
 
-const _ = require('lodash')
 const dependencies = require('./dependencies')
 const desktop = require('./desktop')
+const ElectronInstaller = require('./installer')
 const error = require('./error')
-const fs = require('fs-extra')
 const getDefaultsFromPackageJSON = require('./defaults')
-const glob = require('glob-promise')
-const path = require('path')
 const readElectronVersion = require('./readelectronversion')
 const readMetadata = require('./readmetadata')
 const replaceScopeName = require('./replacescopename')
 const sanitizeName = require('./sanitizename')
 const spawn = require('./spawn')
 const template = require('./template')
-const tmp = require('tmp-promise')
-
-/**
- * Copy `LICENSE` from the root of the app to a different location.
- */
-function copyLicense (options, copyrightFile) {
-  const licenseSrc = path.join(options.src, 'LICENSE')
-  options.logger(`Copying license file from ${licenseSrc}`)
-
-  return fs.copy(licenseSrc, copyrightFile)
-}
-
-/**
- * Create hicolor icon for the package.
- */
-function createHicolorIcon (options, dir, hicolorBaseDir) {
-  const hicolorDir = destinationDir('usr/share/icons/hicolor', hicolorBaseDir)
-  return Promise.all(_.map(options.icon, (icon, resolution) => {
-    const iconExt = resolution === 'scalable' ? 'svg' : 'png'
-    const iconFile = path.join(dir, hicolorDir, resolution, 'apps', `${options.name}.${iconExt}`)
-    options.logger(`Creating icon file at ${iconFile}`)
-
-    return fs.ensureDir(path.dirname(iconFile), '0755')
-      .then(() => fs.copy(icon, iconFile))
-      .then(() => fs.chmod(iconFile, '0644'))
-      .catch(error.wrapError('creating hicolor icon file'))
-  }))
-}
-
-/**
- * Create pixmap icon for the package.
- */
-function createPixmapIcon (options, dir, pixmapsBaseDir) {
-  const pixmapsDir = destinationDir('usr/share/pixmaps', pixmapsBaseDir)
-  const iconFile = path.join(dir, pixmapsDir, `${options.name}.png`)
-  options.logger(`Creating icon file at ${iconFile}`)
-
-  return fs.ensureDir(path.dirname(iconFile), '0755')
-    .catch(error.wrapError('creating icon path'))
-    .then(() => fs.copy(options.icon, iconFile))
-    .then(() => fs.chmod(iconFile, '0644'))
-    .catch(error.wrapError('creating icon file'))
-}
-
-function destinationDir (dir, baseDir) {
-  return baseDir ? path.join(baseDir, dir) : dir
-}
 
 module.exports = {
-  /**
-   * Copies the bundled application into the lib directory.
-   */
-  copyApplication: function copyApplication (options, dir, baseAppDir, ignoreFunc) {
-    const applicationDir = path.join(dir, destinationDir('usr/lib', baseAppDir), options.name)
-    options.logger(`Copying application to ${applicationDir}`)
-
-    return fs.ensureDir(applicationDir, '0755')
-      .then(() => fs.copy(options.src, applicationDir, { filter: ignoreFunc }))
-      .catch(error.wrapError('copying application directory'))
-  },
-  /**
-   * Create the symlink to the binary for the package.
-   */
-  createBinary: function createBinary (options, dir, baseBinDir) {
-    const binDir = path.join(dir, destinationDir('usr/bin', baseBinDir))
-    const binSrc = path.join('../lib', options.name, options.bin)
-    const binDest = path.join(binDir, options.name)
-    options.logger(`Symlinking binary from ${binSrc} to ${binDest}`)
-
-    const bundledBin = path.join(options.src, options.bin)
-
-    return fs.pathExists(bundledBin)
-      .then(exists => {
-        if (!exists) {
-          throw new Error(`could not find the Electron app binary at "${bundledBin}". You may need to re-bundle the app using Electron Packager's "executableName" option.`)
-        }
-        return fs.ensureDir(binDir, '0755')
-      }).then(() => fs.symlink(binSrc, binDest, 'file'))
-      .catch(error.wrapError('creating binary symlink'))
-  },
-  createContents: function createContents (options, dir, functions) {
-    options.logger('Creating contents of package')
-
-    return Promise.all(functions.map(func => func(options, dir)))
-      .then(() => dir)
-      .catch(error.wrapError('creating contents of package'))
-  },
-  /**
-   * Create copyright for the package.
-   */
-  createCopyright: function createCopyright (options, dir, baseDocDir) {
-    const docDir = destinationDir('usr/share/doc', baseDocDir)
-    const copyrightFile = path.join(dir, docDir, options.name, 'copyright')
-    options.logger(`Creating copyright file at ${copyrightFile}`)
-
-    return fs.ensureDir(path.dirname(copyrightFile), '0755')
-      .then(() => copyLicense(options, copyrightFile))
-      .then(() => fs.chmod(copyrightFile, '0644'))
-      .catch(error.wrapError('creating copyright file'))
-  },
-  /**
-   * Create the desktop file for the package.
-   *
-   * See: http://standards.freedesktop.org/desktop-entry-spec/latest/
-   */
-  createDesktop: function createDesktop (options, dir, desktopSrc, applicationsBaseDir) {
-    const baseDir = path.join(dir, destinationDir('usr/share/applications', applicationsBaseDir))
-    return desktop.createDesktopFile(desktopSrc, baseDir, options.name, options)
-  },
-  /**
-   * Create temporary directory where the contents of the package will live.
-   */
-  createDir: function createDir (options) {
-    options.logger('Creating temporary directory')
-
-    return tmp.dir({ prefix: 'electron-', unsafeCleanup: true })
-      .catch(error.wrapError('creating temporary directory'))
-      .then(dir => {
-        const tempDir = path.join(dir.path, `${options.name}_${options.version}_${options.arch}`)
-        return fs.ensureDir(tempDir, '0755')
-      }).catch(error.wrapError('changing permissions on temporary directory'))
-  },
-
-  /**
-   * Create icon for the package.
-   */
-  createIcon: function createIcon (options, dir, baseIconDir) {
-    if (_.isObject(options.icon)) {
-      return createHicolorIcon(options, dir, baseIconDir)
-    } else {
-      return createPixmapIcon(options, dir, baseIconDir)
-    }
-  },
+  createDesktopFile: desktop.createDesktopFile,
   createTemplatedFile: template.createTemplatedFile,
+  ElectronInstaller,
   errorMessage: error.errorMessage,
   generateTemplate: template.generateTemplate,
   getDefaultsFromPackageJSON,
@@ -157,24 +25,10 @@ module.exports = {
   getTrashDepends: dependencies.getTrashDepends,
   getUUIDDepends: dependencies.getUUIDDepends,
   mergeUserSpecified: dependencies.mergeUserSpecified,
-  /**
-   * Move the package to the specified destination.
-   */
-  movePackage: function movePackage (packagePattern, options, dir) {
-    options.logger('Moving package to destination')
-
-    return glob(packagePattern)
-      .then(files => Promise.all(files.map(file => {
-        const template = options.rename(options.dest, path.basename(file))
-        const dest = _.template(template)(options)
-        options.logger(`Moving file ${file} to ${dest}`)
-        return fs.move(file, dest, { clobber: true })
-      }))).catch(error.wrapError('moving package files'))
-  },
-  readElectronVersion: readElectronVersion,
+  readElectronVersion,
   readMeta: readMetadata,
-  replaceScopeName: replaceScopeName,
-  sanitizeName: sanitizeName,
-  spawn: spawn,
+  replaceScopeName,
+  sanitizeName,
+  spawn,
   wrapError: error.wrapError
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const desktop = require('./desktop')
 const ElectronInstaller = require('./installer')
 const error = require('./error')
 const getDefaultsFromPackageJSON = require('./defaults')
+const getHomePage = require('./gethomepage')
 const readElectronVersion = require('./readelectronversion')
 const readMetadata = require('./readmetadata')
 const replaceScopeName = require('./replacescopename')
@@ -22,6 +23,7 @@ module.exports = {
   getDepends: dependencies.getDepends,
   getGConfDepends: dependencies.getGConfDepends,
   getGTKDepends: dependencies.getGTKDepends,
+  getHomePage,
   getTrashDepends: dependencies.getTrashDepends,
   getUUIDDepends: dependencies.getUUIDDepends,
   mergeUserSpecified: dependencies.mergeUserSpecified,

--- a/src/installer.js
+++ b/src/installer.js
@@ -1,0 +1,226 @@
+'use strict'
+
+const _ = require('lodash')
+const debug = require('debug')('electron-installer-common:installer')
+const error = require('./error')
+const glob = require('glob-promise')
+const fs = require('fs-extra')
+const path = require('path')
+const tmp = require('tmp-promise')
+
+class ElectronInstaller {
+  constructor (userSupplied) {
+    this.userSupplied = userSupplied
+  }
+
+  get baseAppDir () {
+    return 'usr'
+  }
+
+  /**
+   * A list of method names to run during `createContents()`.
+   */
+  get contentFunctions () {
+    throw new Error('Please implement contentFunctions')
+  }
+
+  /**
+   * The path to the default .desktop file template.
+   */
+  get defaultDesktopTemplatePath () {
+    throw new Error('Please implement defaultDesktopTemplatePath')
+  }
+
+  get sourceDir () {
+    return this.options.src
+  }
+
+  get stagingAppDir () {
+    return path.join(this.stagingDir, this.baseAppDir, 'lib', this.options.name)
+  }
+
+  /**
+   * Copies the bundled application into the staging directory.
+   */
+  copyApplication (ignoreFunc) {
+    debug(`Copying application to ${this.stagingAppDir}`)
+
+    return fs.ensureDir(this.stagingAppDir, '0755')
+      .then(() => fs.copy(this.sourceDir, this.stagingAppDir, { filter: ignoreFunc }))
+      .catch(error.wrapError('copying application directory'))
+  }
+
+  /**
+   * Create hicolor icon for the package.
+   */
+  copyHicolorIcons () {
+    return Promise.all(_.map(this.options.icon, (iconSrc, resolution) => {
+      const iconExt = resolution === 'scalable' ? 'svg' : 'png'
+      const iconFile = path.join(this.stagingDir, this.baseAppDir, 'share', 'icons', 'hicolor', resolution, 'apps', `${this.options.name}.${iconExt}`)
+
+      return this.copyIcon(iconSrc, iconFile)
+        .catch(error.wrapError('creating hicolor icon file'))
+    }))
+  }
+
+  /**
+   * Generically copy an icon.
+   */
+  copyIcon (src, dest) {
+    debug(`Copying icon file at from "${src}" to "${dest}"`)
+
+    return fs.ensureDir(path.dirname(dest), '0755')
+      .then(() => fs.copy(src, dest))
+      .then(() => fs.chmod(dest, '0644'))
+  }
+
+  /**
+   * Copy `LICENSE` from the root of the app to a different location.
+   */
+  copyLicense (copyrightFile) {
+    const licenseSrc = path.join(this.sourceDir, 'LICENSE')
+    debug(`Copying license file from ${licenseSrc}`)
+
+    return fs.copy(licenseSrc, copyrightFile)
+  }
+
+  /**
+   * Copy icons into the appropriate locations on Linux.
+   */
+  copyLinuxIcons () {
+    if (_.isObject(this.options.icon)) {
+      return this.copyHicolorIcons()
+    } else {
+      return this.copyPixmapIcon()
+    }
+  }
+
+  /**
+   * Create pixmap icon for the package.
+   */
+  copyPixmapIcon () {
+    const iconFile = path.join(this.stagingDir, this.baseAppDir, 'share', 'pixmaps', `${this.options.name}.png`)
+
+    return this.copyIcon(this.options.icon, iconFile)
+      .catch(error.wrapError('creating pixmap icon file'))
+  }
+
+  /**
+   * Create the symlink to the binary for the package.
+   */
+  createBinarySymlink () {
+    const binSrc = path.join('../lib', this.options.name, this.options.bin)
+    const binDest = path.join(this.stagingDir, this.baseAppDir, 'bin', this.options.name)
+    debug(`Symlinking binary from ${binSrc} to ${binDest}`)
+
+    const bundledBin = path.join(this.sourceDir, this.options.bin)
+
+    return fs.pathExists(bundledBin)
+      .then(exists => {
+        if (!exists) {
+          throw new Error(`could not find the Electron app binary at "${bundledBin}". You may need to re-bundle the app using Electron Packager's "executableName" option.`)
+        }
+        return fs.ensureDir(path.dirname(binDest), '0755')
+      }).then(() => fs.symlink(binSrc, binDest, 'file'))
+      .catch(error.wrapError('creating binary symlink'))
+  }
+
+  createContents () {
+    debug('Creating contents of package')
+
+    return Promise.all(this.contentFunctions.map(func => this[func]()))
+      .catch(error.wrapError('creating contents of package'))
+  }
+
+  /**
+   * Create copyright for the package.
+   */
+  createCopyright () {
+    const copyrightFile = path.join(this.stagingDir, this.baseAppDir, 'share', 'doc', this.options.name, 'copyright')
+    debug(`Creating copyright file at ${copyrightFile}`)
+
+    return fs.ensureDir(path.dirname(copyrightFile), '0755')
+      .then(() => this.copyLicense(copyrightFile))
+      .then(() => fs.chmod(copyrightFile, '0644'))
+      .catch(error.wrapError('creating copyright file'))
+  }
+
+  /**
+   * Create the freedesktop.org .desktop file for the package.
+   *
+   * See: http://standards.freedesktop.org/desktop-entry-spec/latest/
+   */
+  createDesktopFile () {
+    const src = this.options.desktopTemplate || this.defaultDesktopTemplatePath
+    const dest = path.join(this.stagingDir, this.baseAppDir, 'share', 'applications', `${this.options.name}.desktop`)
+    debug(`Creating desktop file at ${dest}`)
+
+    return this.createTemplatedFile(src, dest, '0644')
+      .catch(error.wrapError('creating desktop file'))
+  }
+
+  /**
+   * Create temporary directory where the contents of the package will live.
+   */
+  createStagingDir () {
+    debug('Creating staging directory')
+
+    return tmp.dir({ prefix: 'electron-', unsafeCleanup: true })
+      .catch(error.wrapError('creating temporary directory'))
+      .then(dir => {
+        this.stagingDir = path.join(dir.path, `${this.options.name}_${this.options.version}_${this.options.arch}`)
+        return fs.ensureDir(this.stagingDir, '0755')
+      }).catch(error.wrapError('changing permissions on temporary directory'))
+  }
+
+  createTemplatedFile (templatePath, dest, permissions) {
+    return fs.ensureDir(path.dirname(dest), '0755')
+      .then(() => this.generateTemplate(templatePath))
+      .then(data => fs.outputFile(dest, data))
+      .then(() => {
+        if (permissions) {
+          return fs.chmod(dest, permissions)
+        }
+        return Promise.resolve()
+      })
+  }
+
+  /**
+   * Flattens and merges default values, CLI-supplied options, and API-supplied options.
+   */
+  generateOptions () {
+    this.options = _.defaults({}, this.userSupplied, this.userSupplied.options, this.defaults)
+  }
+
+  /**
+   * Fill in a template with the hash of options.
+   */
+  generateTemplate (file, options) {
+    debug(`Generating template from ${file}`)
+    options = options || this.options
+
+    return fs.readFile(file)
+      .then(template => {
+        const result = _.template(template)(options)
+        debug(`Generated template from ${file}\n${result}`)
+        return result
+      })
+  }
+
+  /**
+   * Move the package to the specified destination.
+   */
+  movePackage () {
+    debug('Moving package to destination')
+
+    return glob(this.packagePattern)
+      .then(files => Promise.all(files.map(file => {
+        const template = this.options.rename(this.options.dest, path.basename(file))
+        const dest = _.template(template)(this.options)
+        debug(`Moving file ${file} to ${dest}`)
+        return fs.move(file, dest, { clobber: true })
+      }))).catch(error.wrapError('moving package files'))
+  }
+}
+
+module.exports = ElectronInstaller

--- a/src/installer.js
+++ b/src/installer.js
@@ -188,11 +188,10 @@ class ElectronInstaller {
     debug('Creating staging directory')
 
     return tmp.dir({ prefix: 'electron-', unsafeCleanup: true })
-      .catch(error.wrapError('creating temporary directory'))
       .then(dir => {
         this.stagingDir = path.join(dir.path, `${this.appIdentifier}_${this.options.version}_${this.options.arch}`)
         return fs.ensureDir(this.stagingDir, '0755')
-      }).catch(error.wrapError('changing permissions on temporary directory'))
+      }).catch(error.wrapError('creating staging directory'))
   }
 
   createTemplatedFile (templatePath, dest, filePermissions) {

--- a/src/installer.js
+++ b/src/installer.js
@@ -80,7 +80,12 @@ class ElectronInstaller {
   copyIcon (src, dest) {
     debug(`Copying icon file at from "${src}" to "${dest}"`)
 
-    return fs.ensureDir(path.dirname(dest), '0755')
+    return fs.pathExists(src)
+      .then(exists => {
+        if (!exists) {
+          throw new Error(`The icon "${src}" does not exist`)
+        }
+      }).then(() => fs.ensureDir(path.dirname(dest), '0755'))
       .then(() => fs.copy(src, dest))
       .then(() => fs.chmod(dest, '0644'))
   }
@@ -101,7 +106,7 @@ class ElectronInstaller {
   copyLinuxIcons () {
     if (_.isObject(this.options.icon)) {
       return this.copyHicolorIcons()
-    } else {
+    } else if (this.options.icon) {
       return this.copyPixmapIcon()
     }
   }

--- a/src/installer.js
+++ b/src/installer.js
@@ -23,6 +23,7 @@ class ElectronInstaller {
     return 'usr'
   }
 
+  /* istanbul ignore next */
   /**
    * A list of method names to run during `createContents()`.
    */
@@ -30,6 +31,7 @@ class ElectronInstaller {
     throw new Error('Please implement contentFunctions')
   }
 
+  /* istanbul ignore next */
   /**
    * The path to the default .desktop file template.
    */
@@ -144,6 +146,10 @@ class ElectronInstaller {
       .catch(error.wrapError('creating binary symlink'))
   }
 
+  /**
+   * Generate the contents of the package in "parallel" by calling the methods specified in
+   * `contentFunctions` getter through `Promise.all`.
+   */
   createContents () {
     debug('Creating contents of package')
 

--- a/src/installer.js
+++ b/src/installer.js
@@ -35,6 +35,13 @@ class ElectronInstaller {
     throw new Error('Please implement defaultDesktopTemplatePath')
   }
 
+  /**
+   * The Linux pixmap icon path, relative to the `baseAppDir`.
+   */
+  get pixmapIconPath () {
+    return path.join('share', 'pixmaps', `${this.appIdentifier}.png`)
+  }
+
   get sourceDir () {
     return this.options.src
   }
@@ -103,7 +110,7 @@ class ElectronInstaller {
    * Create pixmap icon for the package.
    */
   copyPixmapIcon () {
-    const iconFile = path.join(this.stagingDir, this.baseAppDir, 'share', 'pixmaps', `${this.appIdentifier}.png`)
+    const iconFile = path.join(this.stagingDir, this.baseAppDir, this.pixmapIconPath)
 
     return this.copyIcon(this.options.icon, iconFile)
       .catch(error.wrapError('creating pixmap icon file'))

--- a/src/installer.js
+++ b/src/installer.js
@@ -13,6 +13,10 @@ class ElectronInstaller {
     this.userSupplied = userSupplied
   }
 
+  get appIdentifier () {
+    return this.options.name
+  }
+
   get baseAppDir () {
     return 'usr'
   }
@@ -36,7 +40,7 @@ class ElectronInstaller {
   }
 
   get stagingAppDir () {
-    return path.join(this.stagingDir, this.baseAppDir, 'lib', this.options.name)
+    return path.join(this.stagingDir, this.baseAppDir, 'lib', this.appIdentifier)
   }
 
   /**
@@ -56,7 +60,7 @@ class ElectronInstaller {
   copyHicolorIcons () {
     return Promise.all(_.map(this.options.icon, (iconSrc, resolution) => {
       const iconExt = resolution === 'scalable' ? 'svg' : 'png'
-      const iconFile = path.join(this.stagingDir, this.baseAppDir, 'share', 'icons', 'hicolor', resolution, 'apps', `${this.options.name}.${iconExt}`)
+      const iconFile = path.join(this.stagingDir, this.baseAppDir, 'share', 'icons', 'hicolor', resolution, 'apps', `${this.appIdentifier}.${iconExt}`)
 
       return this.copyIcon(iconSrc, iconFile)
         .catch(error.wrapError('creating hicolor icon file'))
@@ -99,7 +103,7 @@ class ElectronInstaller {
    * Create pixmap icon for the package.
    */
   copyPixmapIcon () {
-    const iconFile = path.join(this.stagingDir, this.baseAppDir, 'share', 'pixmaps', `${this.options.name}.png`)
+    const iconFile = path.join(this.stagingDir, this.baseAppDir, 'share', 'pixmaps', `${this.appIdentifier}.png`)
 
     return this.copyIcon(this.options.icon, iconFile)
       .catch(error.wrapError('creating pixmap icon file'))
@@ -109,8 +113,8 @@ class ElectronInstaller {
    * Create the symlink to the binary for the package.
    */
   createBinarySymlink () {
-    const binSrc = path.join('../lib', this.options.name, this.options.bin)
-    const binDest = path.join(this.stagingDir, this.baseAppDir, 'bin', this.options.name)
+    const binSrc = path.join('../lib', this.appIdentifier, this.options.bin)
+    const binDest = path.join(this.stagingDir, this.baseAppDir, 'bin', this.appIdentifier)
     debug(`Symlinking binary from ${binSrc} to ${binDest}`)
 
     const bundledBin = path.join(this.sourceDir, this.options.bin)
@@ -136,7 +140,7 @@ class ElectronInstaller {
    * Create copyright for the package.
    */
   createCopyright () {
-    const copyrightFile = path.join(this.stagingDir, this.baseAppDir, 'share', 'doc', this.options.name, 'copyright')
+    const copyrightFile = path.join(this.stagingDir, this.baseAppDir, 'share', 'doc', this.appIdentifier, 'copyright')
     debug(`Creating copyright file at ${copyrightFile}`)
 
     return fs.ensureDir(path.dirname(copyrightFile), '0755')
@@ -152,7 +156,7 @@ class ElectronInstaller {
    */
   createDesktopFile () {
     const src = this.options.desktopTemplate || this.defaultDesktopTemplatePath
-    const dest = path.join(this.stagingDir, this.baseAppDir, 'share', 'applications', `${this.options.name}.desktop`)
+    const dest = path.join(this.stagingDir, this.baseAppDir, 'share', 'applications', `${this.appIdentifier}.desktop`)
     debug(`Creating desktop file at ${dest}`)
 
     return this.createTemplatedFile(src, dest, '0644')
@@ -168,7 +172,7 @@ class ElectronInstaller {
     return tmp.dir({ prefix: 'electron-', unsafeCleanup: true })
       .catch(error.wrapError('creating temporary directory'))
       .then(dir => {
-        this.stagingDir = path.join(dir.path, `${this.options.name}_${this.options.version}_${this.options.arch}`)
+        this.stagingDir = path.join(dir.path, `${this.appIdentifier}_${this.options.version}_${this.options.arch}`)
         return fs.ensureDir(this.stagingDir, '0755')
       }).catch(error.wrapError('changing permissions on temporary directory'))
   }

--- a/test/_util.js
+++ b/test/_util.js
@@ -13,6 +13,10 @@ module.exports = {
     return fs.pathExists(pathToCheck)
       .then(exists => t.false(exists, `File "${pathToCheck}" should not exist`))
   },
+  assertPathPermissions: function assertPathPermissions (t, pathToCheck, expectedPermissions) {
+    return fs.stat(pathToCheck)
+      .then(stats => t.is(stats.mode & 0o7777, expectedPermissions))
+  },
   assertTrimmedFileContents: function assertTrimmedFileContents (t, filePath, expectedContents) {
     return fs.readFile(filePath)
       .then(data => t.is(data.toString().trim(), expectedContents))

--- a/test/_util.js
+++ b/test/_util.js
@@ -17,7 +17,12 @@ module.exports = {
     return fs.stat(pathToCheck)
       .then(stats => {
         const actual = stats.mode & 0o7777
-        return t.is(actual, expectedPermissions, `Expected mode=${expectedPermissions.toString(8)}, got ${actual.toString(8)}`)
+        const msg = `Expected mode=${expectedPermissions.toString(8)}, got ${actual.toString(8)}`
+        if (process.platform === 'win32') {
+          return t.true((actual & expectedPermissions) === expectedPermissions, msg)
+        } else {
+          return t.is(actual, expectedPermissions, msg)
+        }
       })
   },
   assertTrimmedFileContents: function assertTrimmedFileContents (t, filePath, expectedContents) {

--- a/test/_util.js
+++ b/test/_util.js
@@ -17,7 +17,7 @@ module.exports = {
     return fs.stat(pathToCheck)
       .then(stats => {
         const actual = stats.mode & 0o7777
-        return t.is(actual, expectedPermissions, `Expected mode=${expectedPermissions.toString(8)}, got ${actual.toString(8)}`
+        return t.is(actual, expectedPermissions, `Expected mode=${expectedPermissions.toString(8)}, got ${actual.toString(8)}`)
       })
   },
   assertTrimmedFileContents: function assertTrimmedFileContents (t, filePath, expectedContents) {

--- a/test/_util.js
+++ b/test/_util.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const fs = require('fs-extra')
+const path = require('path')
+const tmp = require('tmp-promise')
+
+module.exports = {
+  assertPathExists: function assertPathExists (t, pathToCheck) {
+    return fs.pathExists(pathToCheck)
+      .then(exists => t.true(exists, `File "${pathToCheck}" should exist`))
+  },
+  assertPathNotExists: function assertPathExists (t, pathToCheck) {
+    return fs.pathExists(pathToCheck)
+      .then(exists => t.false(exists, `File "${pathToCheck}" should not exist`))
+  },
+  assertTrimmedFileContents: function assertTrimmedFileContents (t, filePath, expectedContents) {
+    return fs.readFile(filePath)
+      .then(data => t.is(data.toString().trim(), expectedContents))
+  },
+  SIMPLE_TEMPLATE_PATH: path.resolve(__dirname, 'fixtures', 'template', 'simple.ejs'),
+  unsafeTempDir: function unsafeTempDir (promise) {
+    return tmp.withDir(promise, { unsafeCleanup: true })
+  }
+}

--- a/test/_util.js
+++ b/test/_util.js
@@ -15,7 +15,10 @@ module.exports = {
   },
   assertPathPermissions: function assertPathPermissions (t, pathToCheck, expectedPermissions) {
     return fs.stat(pathToCheck)
-      .then(stats => t.is(stats.mode & 0o7777, expectedPermissions))
+      .then(stats => {
+        const actual = stats.mode & 0o7777
+        return t.is(actual, expectedPermissions, `Expected mode=${expectedPermissions.toString(8)}, got ${actual.toString(8)}`
+      })
   },
   assertTrimmedFileContents: function assertTrimmedFileContents (t, filePath, expectedContents) {
     return fs.readFile(filePath)

--- a/test/desktop.js
+++ b/test/desktop.js
@@ -1,18 +1,14 @@
 'use strict'
 
 const { createDesktopFile } = require('../src/desktop')
-const fs = require('fs-extra')
 const path = require('path')
 const test = require('ava')
-const tmp = require('tmp-promise')
-
-const SIMPLE_TEMPLATE_PATH = path.resolve(__dirname, 'fixtures', 'template', 'simple.ejs')
+const util = require('./_util')
 
 test('createDesktopFile', t => {
-  return tmp.withDir(dir => {
+  return util.unsafeTempDir(dir => {
     const renderedPath = path.join(dir.path, 'rendered.desktop')
-    return createDesktopFile(SIMPLE_TEMPLATE_PATH, dir.path, 'rendered', { name: 'World' })
-      .then(() => fs.pathExists(renderedPath))
-      .then(exists => t.true(exists))
-  }, { unsafeCleanup: true })
+    return createDesktopFile(util.SIMPLE_TEMPLATE_PATH, dir.path, 'rendered', { name: 'World' })
+      .then(() => util.assertPathExists(t, renderedPath))
+  })
 })

--- a/test/desktop.js
+++ b/test/desktop.js
@@ -9,6 +9,6 @@ test('createDesktopFile', t => {
   return util.unsafeTempDir(dir => {
     const renderedPath = path.join(dir.path, 'rendered.desktop')
     return createDesktopFile(util.SIMPLE_TEMPLATE_PATH, dir.path, 'rendered', { name: 'World' })
-      .then(() => util.assertPathExists(t, renderedPath))
+      .then(() => util.assertPathPermissions(t, renderedPath, 0o644))
   })
 })

--- a/test/installer.js
+++ b/test/installer.js
@@ -13,6 +13,7 @@ test('createBinarySymlink creates symlink when bin exists', t => {
     src: path.join(__dirname, 'fixtures', 'bundled_app')
   }
   const installer = new ElectronInstaller(options)
+  installer.generateOptions()
   return installer.createStagingDir()
     .then(() => installer.createBinarySymlink())
     .then(() => fs.lstat(path.join(installer.stagingDir, installer.baseAppDir, 'bin', 'bundled_app')))
@@ -27,6 +28,8 @@ test('createBinarySymlink does not create symlink when bin does not exist', t =>
     src: path.join(__dirname, 'fixtures', 'bundled_app')
   }
   const installer = new ElectronInstaller(options)
+  installer.generateOptions()
   return installer.createStagingDir()
+    .then(() => installer.createStagingDir())
     .then(() => t.throwsAsync(installer.createBinarySymlink(), /could not find the Electron app binary/))
 })

--- a/test/installer.js
+++ b/test/installer.js
@@ -3,7 +3,74 @@
 const { ElectronInstaller } = require('..')
 const fs = require('fs-extra')
 const path = require('path')
+const sinon = require('sinon')
 const test = require('ava')
+const util = require('./_util')
+
+test('copyApplication', t => {
+  const installer = new ElectronInstaller({ name: 'copyapp', src: path.join(__dirname, 'fixtures', 'app-with-asar') })
+  installer.generateOptions()
+  return installer.createStagingDir()
+    .then(() => installer.copyApplication())
+    .then(() => util.assertPathExists(t, installer.stagingAppDir))
+    .then(() => util.assertPathExists(t, path.join(installer.stagingAppDir, 'footest')))
+})
+
+test('copyApplication with ignore func', t => {
+  const installer = new ElectronInstaller({ name: 'copyapp', src: path.join(__dirname, 'fixtures', 'app-with-asar') })
+  installer.generateOptions()
+  return installer.createStagingDir()
+    .then(() => installer.copyApplication(src => src !== path.join(installer.sourceDir, 'LICENSE')))
+    .then(() => util.assertPathExists(t, path.join(installer.stagingAppDir, 'footest')))
+    .then(() => util.assertPathNotExists(t, path.join(installer.stagingAppDir, 'LICENSE')))
+})
+
+test('copyLinuxIcons for hicolor icons', t => {
+  const hicolorDir = path.join('usr', 'share', 'icons', 'hicolor')
+  const img = path.join(__dirname, 'fixtures', 'icon.fake')
+  const installer = new ElectronInstaller({
+    name: 'icontest',
+    icon: {
+      scalable: img,
+      '48x48': img
+    }
+  })
+  installer.generateOptions()
+  return installer.createStagingDir()
+    .then(() => installer.copyLinuxIcons())
+    .then(() => util.assertPathExists(t, path.join(installer.stagingDir, hicolorDir, '48x48', 'apps', 'icontest.png')))
+    .then(() => util.assertPathExists(t, path.join(installer.stagingDir, hicolorDir, 'scalable', 'apps', 'icontest.svg')))
+})
+
+test('copyLinuxIcons for pixmap', t => {
+  const installer = new ElectronInstaller({
+    name: 'icontest',
+    icon: path.join(__dirname, 'fixtures', 'icon.fake')
+  })
+  installer.generateOptions()
+  return installer.createStagingDir()
+    .then(() => installer.copyLinuxIcons())
+    .then(() => util.assertPathExists(t, path.join(installer.stagingDir, 'usr', 'share', 'pixmaps', 'icontest.png')))
+})
+
+test('copyLinuxIcon with a nonexistent source icon', t => {
+  const installer = new ElectronInstaller({
+    name: 'icontest',
+    icon: path.join(__dirname, 'fixtures', 'icons', 'nonexistent.png')
+  })
+  installer.generateOptions()
+  return installer.createStagingDir()
+    .then(() => t.throwsAsync(installer.copyLinuxIcons(), /The icon ".*" does not exist$/))
+})
+
+test('copyLinuxIcons does nothing if icon option not specified', t => {
+  const installer = new ElectronInstaller({ name: 'icontest' })
+  installer.generateOptions()
+  return installer.createStagingDir()
+    .then(() => installer.copyLinuxIcons())
+    .then(() => util.assertPathNotExists(t, path.join(installer.stagingDir, 'usr', 'share', 'pixmaps')))
+    .then(() => util.assertPathNotExists(t, path.join(installer.stagingDir, 'usr', 'share', 'icons')))
+})
 
 test('createBinarySymlink creates symlink when bin exists', t => {
   const options = {
@@ -30,6 +97,82 @@ test('createBinarySymlink does not create symlink when bin does not exist', t =>
   const installer = new ElectronInstaller(options)
   installer.generateOptions()
   return installer.createStagingDir()
-    .then(() => installer.createStagingDir())
     .then(() => t.throwsAsync(installer.createBinarySymlink(), /could not find the Electron app binary/))
+})
+
+test('createContents', t => {
+  const installer = new ElectronInstaller({ name: 'World' })
+  installer.createFakeContent = sinon.spy()
+  sinon.stub(installer, 'contentFunctions').get(() => ['createFakeContent'])
+  return installer.createContents()
+    .then(() => t.true(installer.createFakeContent.called))
+})
+
+test('createCopyright', t => {
+  return util.unsafeTempDir(dir => {
+    const installer = new ElectronInstaller({ name: 'copyright-test', src: dir.path })
+    installer.generateOptions()
+    return installer.createStagingDir()
+      .then(() => fs.outputFile(path.join(dir.path, 'LICENSE'), 'License'))
+      .then(() => installer.createCopyright())
+      .then(() => util.assertTrimmedFileContents(t, path.join(installer.stagingDir, 'usr', 'share', 'doc', 'copyright-test', 'copyright'), 'License'))
+  })
+})
+
+test('createDesktopFile with default template', t => {
+  const installer = new ElectronInstaller({ name: 'World' })
+  sinon.stub(installer, 'defaultDesktopTemplatePath').get(() => util.SIMPLE_TEMPLATE_PATH)
+  installer.generateOptions()
+  return installer.createStagingDir()
+    .then(() => installer.createDesktopFile())
+    .then(() => util.assertPathExists(t, path.join(installer.stagingDir, 'usr', 'share', 'applications', 'World.desktop')))
+})
+
+test('createDesktopFile with custom desktopTemplate', t => {
+  const installer = new ElectronInstaller({ name: 'World', desktopTemplate: util.SIMPLE_TEMPLATE_PATH })
+  installer.generateOptions()
+  return installer.createStagingDir()
+    .then(() => installer.createDesktopFile())
+    .then(() => util.assertPathExists(t, path.join(installer.stagingDir, 'usr', 'share', 'applications', 'World.desktop')))
+})
+
+test('createTemplatedFile', t => {
+  return util.unsafeTempDir(dir => {
+    const renderedPath = path.join(dir.path, 'rendered')
+    const installer = new ElectronInstaller({ name: 'World' })
+    installer.generateOptions()
+    return installer.createTemplatedFile(util.SIMPLE_TEMPLATE_PATH, renderedPath)
+      .then(() => util.assertTrimmedFileContents(t, renderedPath, 'Hello, World!'))
+  })
+})
+
+test('generateOptions merges default values & CLI options', t => {
+  const installer = new ElectronInstaller({ options: { name: 'CLI' } })
+  installer.defaults = { name: 'Default', description: 'Default' }
+  installer.generateOptions()
+  t.is(installer.options.name, 'CLI')
+  t.is(installer.options.description, 'Default')
+})
+
+test('generateOptions merges API values & CLI options', t => {
+  const installer = new ElectronInstaller({ name: 'API', options: { name: 'CLI' } })
+  installer.defaults = { name: 'Default' }
+  installer.generateOptions()
+  t.is(installer.options.name, 'API')
+})
+
+test('movePackage', t => {
+  return util.unsafeTempDir(dir => {
+    const destDir = path.join(dir.path, 'moveTo')
+    const rename = (dest, src) => {
+      return path.join(dest, 'test_<%= name %>.pkg')
+    }
+    const installer = new ElectronInstaller({ name: 'foo', dest: destDir, rename: rename })
+    installer.generateOptions()
+    installer.packagePattern = path.join(dir.path, '*.pkg')
+    return fs.ensureDir(destDir)
+      .then(() => fs.outputFile(path.join(dir.path, 'test.pkg'), 'hello'))
+      .then(() => installer.movePackage())
+      .then(() => util.assertPathExists(t, path.join(destDir, 'test_foo.pkg')))
+  })
 })

--- a/test/template.js
+++ b/test/template.js
@@ -21,8 +21,8 @@ test('createTemplatedFile', t => {
 test('createTemplatedFile with permissions', t => {
   return util.unsafeTempDir(dir => {
     const renderedPath = path.join(dir.path, 'rendered')
-    return template.createTemplatedFile(util.SIMPLE_TEMPLATE_PATH, renderedPath, { name: 'World' }, 0o744)
+    return template.createTemplatedFile(util.SIMPLE_TEMPLATE_PATH, renderedPath, { name: 'World' }, 0o644)
       .then(() => util.assertTrimmedFileContents(t, renderedPath, 'Hello, World!'))
-      .then(() => util.assertPathPermissions(t, renderedPath, 0o744))
+      .then(() => util.assertPathPermissions(t, renderedPath, 0o644))
   })
 })

--- a/test/template.js
+++ b/test/template.js
@@ -4,30 +4,26 @@ const fs = require('fs-extra')
 const path = require('path')
 const template = require('../src/template')
 const test = require('ava')
-const tmp = require('tmp-promise')
-
-const SIMPLE_TEMPLATE_PATH = path.resolve(__dirname, 'fixtures', 'template', 'simple.ejs')
+const util = require('./_util')
 
 test('generateTemplate', t => {
-  return template.generateTemplate(SIMPLE_TEMPLATE_PATH, { name: 'World' })
+  return template.generateTemplate(util.SIMPLE_TEMPLATE_PATH, { name: 'World' })
     .then(data => t.is(data.trim(), 'Hello, World!'))
 })
 
 test('createTemplatedFile', t => {
-  return tmp.withDir(dir => {
+  return util.unsafeTempDir(dir => {
     const renderedPath = path.join(dir.path, 'rendered')
-    return template.createTemplatedFile(SIMPLE_TEMPLATE_PATH, renderedPath, { name: 'World' })
-      .then(() => fs.readFile(renderedPath))
-      .then(data => t.is(data.toString().trim(), 'Hello, World!'))
-  }, { unsafeCleanup: true })
+    return template.createTemplatedFile(util.SIMPLE_TEMPLATE_PATH, renderedPath, { name: 'World' })
+      .then(() => util.assertTrimmedFileContents(t, renderedPath, 'Hello, World!'))
+  })
 })
 
 test('createTemplatedFile with permissions', t => {
-  return tmp.withDir(dir => {
+  return util.unsafeTempDir(dir => {
     const renderedPath = path.join(dir.path, 'rendered')
-    return template.createTemplatedFile(SIMPLE_TEMPLATE_PATH, renderedPath, { name: 'World' }, 0o744)
-      .then(() => fs.readFile(renderedPath))
-      .then(data => t.is(data.toString().trim(), 'Hello, World!'))
+    return template.createTemplatedFile(util.SIMPLE_TEMPLATE_PATH, renderedPath, { name: 'World' }, 0o744)
+      .then(() => util.assertTrimmedFileContents(t, renderedPath, 'Hello, World!'))
       .then(() => fs.access(renderedPath, fs.constants.X_OK))
-  }, { unsafeCleanup: true })
+  })
 })

--- a/test/template.js
+++ b/test/template.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const fs = require('fs-extra')
 const path = require('path')
 const template = require('../src/template')
 const test = require('ava')
@@ -24,6 +23,6 @@ test('createTemplatedFile with permissions', t => {
     const renderedPath = path.join(dir.path, 'rendered')
     return template.createTemplatedFile(util.SIMPLE_TEMPLATE_PATH, renderedPath, { name: 'World' }, 0o744)
       .then(() => util.assertTrimmedFileContents(t, renderedPath, 'Hello, World!'))
-      .then(() => fs.access(renderedPath, fs.constants.X_OK))
+      .then(() => util.assertPathPermissions(t, renderedPath, 0o744))
   })
 })


### PR DESCRIPTION
Refactors most of the functions in `src/index.js` into a structured class. Installer modules can be subclassed.

I have successfully converted 4 of the known `electron-installer-*` modules to use this:

* `-debian`
* `-redhat`
* `-flatpak` _(my fork of it)_
* `-windows` _(a fork of the current `-common` PR)_

I designed `-snap` a bit differently, so I'm only using extracted functions, but I think this (large) change is ready for some review.

Fixes #8.