### PR TITLE
Upgrade asar to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "sinon": "^7.2.2"
   },
   "dependencies": {
-    "asar": "^0.14.6",
+    "asar": "^1.0.0",
     "cross-spawn-promise": "^0.10.1",
     "debug": "^4.1.1",
     "fs-extra": "^7.0.1",


### PR DESCRIPTION
@fcastilloec I'm fast-tracking this because I was a part of the upgrade, I know what's in it, and the upgrade in this module wasn't as bad as it was in Packager, since `asar.extractFile` is sync and so really didn't change. The important thing is that `asar@1.0.0` removes a package with a security vulnerability.