### PR TITLE
Travis: fix windows builds failing even after success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ dist: xenial
 cache:
 - npm: true
 - yarn: true
+env:
+- YARN_GPG=no
 branches:
   only:
   - master


### PR DESCRIPTION
@malept I noticed that the majority of the previous PRs were failing on Travis because of this issue. It's because of the switch to `yarn` rather than using `npm`.
Nonetheless, maybe we should consider blocking merging PR that fail Travis testing now that this PR fixes it.