### PR TITLE
feat: add packagePaths to options when calling ElectronInstaller.movePackage()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/electron-userland/electron-installer-common/compare/v0.7.1...master
 
+### Added
+
+* Add `packagePaths` to `options` when calling `ElectronInstaller.movePackage()`
+
 ## [0.7.1] - 2019-06-09
 
 [0.7.1]: https://github.com/electron-userland/electron-installer-common/compare/v0.7.0...v0.7.1

--- a/src/installer.js
+++ b/src/installer.js
@@ -210,17 +210,21 @@ class ElectronInstaller {
 
   /**
    * Move the package to the specified destination.
+   *
+   * Also adds `packagePaths` to `options`, which is an `Array` of the absolute paths to the
+   * moved packages.
    */
   async movePackage () {
     debug('Moving package to destination')
 
     return error.wrapError('moving package files', async () => {
       const files = await glob(this.packagePattern)
-      return Promise.all(files.map(async file => {
+      this.options.packagePaths = await Promise.all(files.map(async file => {
         const renameTemplate = this.options.rename(this.options.dest, path.basename(file))
         const dest = _.template(renameTemplate)(this.options)
         debug(`Moving file ${file} to ${dest}`)
-        return fs.move(file, dest, { clobber: true })
+        await fs.move(file, dest, { clobber: true })
+        return dest
       }))
     })
   }

--- a/test/installer.js
+++ b/test/installer.js
@@ -173,7 +173,9 @@ test('movePackage', t => {
     await fs.ensureDir(destDir)
     await fs.outputFile(path.join(dir.path, 'test.pkg'), 'hello')
     await installer.movePackage()
-    await util.assertPathExists(t, path.join(destDir, 'test_foo.pkg'))
+    const expectedPackagePath = path.join(destDir, 'test_foo.pkg')
+    t.deepEqual(installer.options.packagePaths, [expectedPackagePath])
+    await util.assertPathExists(t, expectedPackagePath)
   })
 })
 


### PR DESCRIPTION
Electron Forge needs to know what the final paths of the distributables that `electron-installer-*` generate, so it can do things like publish to service X. Since `-debian` and `-redhat` have options that allow a user to customize what the name is, the installer modules need to pass back the resulting package file paths.