### PR TITLE
Generate or-ed dependency lists for dependencies with varying names

### DIFF
--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -47,6 +47,10 @@ function getUUIDDepends (version, dependencyMap) {
   return semver.gte(version, '4.0.0-beta.1') ? getAlternativeDepends(dependencyMap.uuid) : []
 }
 
+/**
+ * Returns an array with 1 package (no alternatives available) or an Array with an 'or-ed' list
+ * of packages if there are multiple alternatives available.
+ */
 function getAlternativeDepends(dependencyMapPackage) {
   if (dependencyMapPackage.length == 1) {
     return [dependencyMapPackage[0]];

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -44,16 +44,14 @@ function getTrashDepends (version, dependencyMap) {
  * Determine whether libuuid is necessary, given the Electron version.
  */
 function getUUIDDepends (version, dependencyMap) {
-  return semver.gte(version, '4.0.0-beta.1') ? getAlternativeDepends(dependencyMap, 'uuid') : []
+  return semver.gte(version, '4.0.0-beta.1') ? getAlternativeDepends(dependencyMap.uuid) : []
 }
 
-function getAlternativeDepends(dependencyMap, package) {
-  var depends = dependencyMap[package];
-
-  if (depends.length == 1) {
-    return [depends[0]];
+function getAlternativeDepends(dependencyMapPackage) {
+  if (dependencyMapPackage.length == 1) {
+    return [dependencyMapPackage[0]];
   } else {
-    return [`(${depends.join(' or ')})`]
+    return [`(${dependencyMapPackage.join(' or ')})`]
   }
 }
 
@@ -64,10 +62,10 @@ module.exports = {
   getDepends: function getDepends (version, dependencyMap) {
     return [
       getGTKDepends(version, dependencyMap),
-      getAlternativeDepends(dependencyMap, 'notify'),
-      getAlternativeDepends(dependencyMap, 'nss'),
+      getAlternativeDepends(dependencyMap.notify),
+      getAlternativeDepends(dependencyMap.nss),
       dependencyMap.xss,
-      getAlternativeDepends(dependencyMap, 'xtst'),
+      getAlternativeDepends(dependencyMap.xtst),
       dependencyMap.xdgUtils
     ].concat(getATSPIDepends(version, dependencyMap))
       .concat(getGConfDepends(version, dependencyMap))

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -44,7 +44,17 @@ function getTrashDepends (version, dependencyMap) {
  * Determine whether libuuid is necessary, given the Electron version.
  */
 function getUUIDDepends (version, dependencyMap) {
-  return semver.gte(version, '4.0.0-beta.1') ? [dependencyMap.uuid] : []
+  return semver.gte(version, '4.0.0-beta.1') ? getAlternativeDepends(dependencyMap, 'uuid') : []
+}
+
+function getAlternativeDepends(dependencyMap, package) {
+  var depends = dependencyMap[package];
+
+  if (depends.length == 1) {
+    return [depends[0]];
+  } else {
+    return [`(${depends.join(' or ')})`]
+  }
 }
 
 module.exports = {
@@ -54,10 +64,10 @@ module.exports = {
   getDepends: function getDepends (version, dependencyMap) {
     return [
       getGTKDepends(version, dependencyMap),
-      dependencyMap.notify,
-      dependencyMap.nss,
+      getAlternativeDepends(dependencyMap, 'notify'),
+      getAlternativeDepends(dependencyMap, 'nss'),
       dependencyMap.xss,
-      dependencyMap.xtst,
+      getAlternativeDepends(dependencyMap, 'xtst'),
       dependencyMap.xdgUtils
     ].concat(getATSPIDepends(version, dependencyMap))
       .concat(getGConfDepends(version, dependencyMap))


### PR DESCRIPTION
This pull request addresses [electron-installer-redhat #130](https://github.com/electron-userland/electron-installer-redhat/issues/130). Certain standard packages (namely libnotify, nss, libXtst, libuuid) have varying names depending on the exact RPM-based distribution (RedHat, Suse, ...). For these packages it is necessary to generate or-ed dependency lists, so that the resulting package works on different distributions.