### PR TITLE
fix(dependencies): remove UUID dependency for Electron >=8.0.0-beta.1

### DIFF
--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -44,7 +44,7 @@ function getTrashDepends (version, dependencyMap) {
  * Determine whether libuuid is necessary, given the Electron version.
  */
 function getUUIDDepends (version, dependencyMap) {
-  return semver.gte(version, '4.0.0-beta.1') ? [dependencyMap.uuid] : []
+  return semver.satisfies(version, '>=4.0.0-beta.1 <8.0.0-beta.1') ? [dependencyMap.uuid] : []
 }
 
 module.exports = {

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -81,7 +81,7 @@ test('getUUIDDepends: returns uuid as of 4.0', t => {
   t.is(dependencies.getUUIDDepends('4.0.0', dependencyMap)[0], dependencyMap.uuid)
 })
 
-test('getUUIDDepends: returns nothing as of 8.0-beta.1', t => {
+test('getUUIDDepends: returns nothing as of 8.0.0-beta.1', t => {
   t.is(dependencies.getUUIDDepends('8.0.0', dependencyMap).length, 0)
 })
 

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -81,6 +81,10 @@ test('getUUIDDepends: returns uuid as of 4.0', t => {
   t.is(dependencies.getUUIDDepends('4.0.0', dependencyMap)[0], dependencyMap.uuid)
 })
 
+test('getUUIDDepends: returns nothing as of 8.0-beta.1', t => {
+  t.is(dependencies.getUUIDDepends('8.0.0', dependencyMap).length, 0)
+})
+
 function testMergeUserSpecified (t, dataPath) {
   const defaults = {
     dependencies: ['lsb', 'libXScrnSaver']


### PR DESCRIPTION
We will also have to upgrade `-debian` and `-redhat` to use this.