### PR TITLE
fix(installer): allow sourceDir to be used before options is set

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -52,7 +52,15 @@ class ElectronInstaller {
   }
 
   get sourceDir () {
-    return this.options.src
+    if (this.options) {
+      return this.options.src
+    } else if (this.userSupplied.src) {
+      return this.userSupplied.src
+    } else if (this.userSupplied.options) {
+      return this.userSupplied.options.src
+    }
+
+    return undefined
   }
 
   /**

--- a/test/installer.js
+++ b/test/installer.js
@@ -7,6 +7,17 @@ const sinon = require('sinon')
 const test = require('ava')
 const util = require('./_util')
 
+test('sourceDir usable before options are set', t => {
+  const src = path.join(__dirname, 'fixtures', 'app-with-asar')
+  const installer = new ElectronInstaller({ name: 'copyapp', src })
+  t.is(src, installer.sourceDir)
+  delete installer.userSupplied.src
+  installer.userSupplied.options = { src }
+  t.is(src, installer.sourceDir)
+  delete installer.userSupplied.options
+  t.is(undefined, installer.sourceDir)
+})
+
 test('copyApplication', async t => {
   const installer = new ElectronInstaller({ name: 'copyapp', src: path.join(__dirname, 'fixtures', 'app-with-asar') })
   installer.generateOptions()


### PR DESCRIPTION
Needed in the case where we introspect the source directory when generating defaults.