### PR TITLE
feat(sandboxhelper): add hasSandboxHelper

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "tmp-promise": "^2.0.1"
   },
   "engines": {
-    "node": ">= 8.0"
+    "node": ">= 8.3.0"
   },
   "ava": {
     "babel": false,

--- a/src/index.js
+++ b/src/index.js
@@ -12,9 +12,10 @@ const replaceScopeName = require('./replacescopename')
 const sanitizeName = require('./sanitizename')
 const spawn = require('./spawn')
 const template = require('./template')
-const updateSandboxHelperPermissions = require('./sandboxhelper')
+const sandboxHelper = require('./sandboxhelper')
 
 module.exports = {
+  ...sandboxHelper,
   createDesktopFile: desktop.createDesktopFile,
   createTemplatedFile: template.createTemplatedFile,
   ElectronInstaller,
@@ -33,6 +34,5 @@ module.exports = {
   replaceScopeName,
   sanitizeName,
   spawn,
-  updateSandboxHelperPermissions,
   wrapError: error.wrapError
 }

--- a/src/installer.js
+++ b/src/installer.js
@@ -11,7 +11,7 @@ const glob = promisify(require('glob'))
 const path = require('path')
 const template = require('./template')
 const tmp = require('tmp-promise')
-const updateSandboxHelperPermissions = require('./sandboxhelper')
+const { updateSandboxHelperPermissions } = require('./sandboxhelper')
 
 tmp.setGracefulCleanup()
 

--- a/src/sandboxhelper.js
+++ b/src/sandboxhelper.js
@@ -4,18 +4,33 @@ const fs = require('fs-extra')
 const path = require('path')
 
 /**
- * For Electron versions that support the setuid sandbox on Linux, changes the permissions of
- * the `chrome-sandbox` executable as appropriate.
- *
- * The sandbox helper executable must have the setuid (`+s` / `0o4000`) bit set.
- *
- * This doesn't work on Windows because you can't set that bit there.
- *
- * See: https://github.com/electron/electron/pull/17269#issuecomment-470671914
+ * Returns the path to chrome-sandbox if it exists, undefined otherwise.
  */
-module.exports = async function updateSandboxHelperPermissions (appDir) {
-  const sandboxHelperPath = path.join(appDir, 'chrome-sandbox')
-  if (await fs.pathExists(sandboxHelperPath)) {
-    return fs.chmod(sandboxHelperPath, 0o4755)
+async function sandboxHelperPath (appDir) {
+  const helperPath = path.join(appDir, 'chrome-sandbox')
+  if (await fs.pathExists(helperPath)) {
+    return helperPath
+  }
+}
+
+module.exports = {
+  hasSandboxHelper: async function hasSandboxHelper (appDir) {
+    return typeof (await sandboxHelperPath(appDir)) !== 'undefined'
+  },
+  /**
+   * For Electron versions that support the setuid sandbox on Linux, changes the permissions of
+   * the `chrome-sandbox` executable as appropriate.
+   *
+   * The sandbox helper executable must have the setuid (`+s` / `0o4000`) bit set.
+   *
+   * This doesn't work on Windows because you can't set that bit there.
+   *
+   * See: https://github.com/electron/electron/pull/17269#issuecomment-470671914
+   */
+  updateSandboxHelperPermissions: async function updateSandboxHelperPermissions (appDir) {
+    const helperPath = await sandboxHelperPath(appDir)
+    if (typeof helperPath !== 'undefined') {
+      return fs.chmod(helperPath, 0o4755)
+    }
   }
 }

--- a/test/sandboxhelper.js
+++ b/test/sandboxhelper.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const fs = require('fs-extra')
+const { hasSandboxHelper } = require('../src/sandboxhelper')
+const path = require('path')
+const test = require('ava')
+const util = require('./_util')
+
+test('hasSandboxHelper returns true when chrome-sandbox exists', t => {
+  return util.unsafeTempDir(async dir => {
+    await fs.writeFile(path.join(dir.path, 'chrome-sandbox'), '')
+    t.true(await hasSandboxHelper(dir.path))
+  })
+})
+
+test('hasSandboxhelper returns false when chrome-sandbox does not exist', t => {
+  return util.unsafeTempDir(async dir => {
+    t.false(await hasSandboxHelper(dir.path))
+  })
+})


### PR DESCRIPTION
BREAKING CHANGE: now requires Node 8.3.0 instead of Node 8.0.0, due to the use of Object spread properties.