### PR TITLE
refactor: replace cross-spawn-promise with cross-spawn

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "asar": "^2.0.1",
-    "cross-spawn-promise": "^0.10.1",
+    "cross-spawn": "^7.0.1",
     "debug": "^4.1.1",
     "fs-extra": "^8.0.1",
     "glob": "^7.1.4",

--- a/src/spawn.js
+++ b/src/spawn.js
@@ -1,24 +1,39 @@
 'use strict'
 
-const spawn = require('cross-spawn-promise')
+const spawn = require('cross-spawn')
 
 /**
  * Spawn a child process and make the error message more human friendly, if possible.
  *
+ * If logger is specified, it's usually a debug or console.log function pointer.
  * Specify updateErrorCallback (a callback) to adjust the error object before it is rethrown.
  */
 module.exports = async function (cmd, args, logger, updateErrorCallback) {
   if (logger) logger(`Executing command ${cmd} ${args.join(' ')}`)
 
-  try {
-    const stdout = await spawn(cmd, args)
-    return stdout.toString()
-  } catch (err) {
-    const stderr = err.stderr ? err.stderr.toString() : ''
-    if (updateErrorCallback) {
-      updateErrorCallback(err, !!logger)
-    }
-
-    throw new Error(`Error executing command (${err.message || err}):\n${cmd} ${args.join(' ')}\n${stderr}`)
-  }
+  return new Promise((resolve, reject) => {
+    let stdout = ''
+    let stderr = ''
+    const process = spawn(cmd, args)
+    process.stdout.on('data', data => {
+      stdout += data.toString()
+    })
+    process.stderr.on('data', data => {
+      /* istanbul ignore next */
+      stderr += data.toString()
+    })
+    process.on('close', code => {
+      if (code === 0) {
+        resolve(stdout)
+      } else {
+        reject(new Error(`Command failed with a non-zero return code (${code}):\n${cmd} ${args.join(' ')}\n${stdout}\n${stderr}`))
+      }
+    })
+    process.on('error', err => {
+      if (updateErrorCallback) {
+        updateErrorCallback(err, !!logger)
+      }
+      reject(new Error(`Error executing command (${err.message || err}):\n${cmd} ${args.join(' ')}\n${stderr}`))
+    })
+  })
 }


### PR DESCRIPTION
`cross-spawn-promise` hasn't been updated in over 2 years and is stuck on an old version of `cross-spawn`. Additionally, it has an issue with its TypeScript definition in that you can't specify several options _(not that it's a problem here, but I ran into it elsewhere)_.