### PR TITLE
feat(installer): add support for symbolic icons

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -87,7 +87,7 @@ class ElectronInstaller {
    */
   async copyHicolorIcons () {
     return Promise.all(_.map(this.options.icon, (iconSrc, resolution) => {
-      const iconExt = resolution === 'scalable' || resolution === 'symbolic' ? 'svg' : 'png'
+      const iconExt = ['scalable', 'symbolic'].includes(resolution) ? 'svg' : 'png'
       const iconName = resolution === 'symbolic' ? `${this.appIdentifier}-symbolic` : this.appIdentifier
       const iconFile = path.join(this.stagingDir, this.baseAppDir, 'share', 'icons', 'hicolor', resolution, 'apps', `${iconName}.${iconExt}`)
 

--- a/src/installer.js
+++ b/src/installer.js
@@ -87,8 +87,9 @@ class ElectronInstaller {
    */
   async copyHicolorIcons () {
     return Promise.all(_.map(this.options.icon, (iconSrc, resolution) => {
-      const iconExt = resolution === 'scalable' ? 'svg' : 'png'
-      const iconFile = path.join(this.stagingDir, this.baseAppDir, 'share', 'icons', 'hicolor', resolution, 'apps', `${this.appIdentifier}.${iconExt}`)
+      const iconExt = resolution === 'scalable' || resolution === 'symbolic' ? 'svg' : 'png'
+      const iconName = resolution === 'symbolic' ? `${this.appIdentifier}-symbolic` : this.appIdentifier
+      const iconFile = path.join(this.stagingDir, this.baseAppDir, 'share', 'icons', 'hicolor', resolution, 'apps', `${iconName}.${iconExt}`)
 
       return error.wrapError('creating hicolor icon file', async () => this.copyIcon(iconSrc, iconFile))
     }))

--- a/test/installer.js
+++ b/test/installer.js
@@ -43,6 +43,7 @@ test('copyLinuxIcons for hicolor icons', async t => {
     name: 'icontest',
     icon: {
       scalable: img,
+      symbolic: img,
       '48x48': img
     }
   })
@@ -51,6 +52,7 @@ test('copyLinuxIcons for hicolor icons', async t => {
   await installer.copyLinuxIcons()
   await util.assertPathExists(t, path.join(installer.stagingDir, hicolorDir, '48x48', 'apps', 'icontest.png'))
   await util.assertPathExists(t, path.join(installer.stagingDir, hicolorDir, 'scalable', 'apps', 'icontest.svg'))
+  await util.assertPathExists(t, path.join(installer.stagingDir, hicolorDir, 'symbolic', 'apps', 'icontest-symbolic.svg'))
 })
 
 test('copyLinuxIcons for pixmap', async t => {


### PR DESCRIPTION
See https://developer.gnome.org/ThemedIcons/ for more info on symbolic icons. We currently only support `SVG` for this type of icons, since it's the preferred one.