### PR TITLE
feat: add TypeScript definition

### DIFF
--- a/.eslintrc.typescript.js
+++ b/.eslintrc.typescript.js
@@ -1,0 +1,13 @@
+const { eslintConfig } = require('./package.json')
+eslintConfig.parser = '@typescript-eslint/parser'
+eslintConfig.extends.push('plugin:@typescript-eslint/recommended')
+
+eslintConfig.rules = {
+  'comma-dangle': ['error', 'only-multiline'],
+  'no-useless-constructor': 'off',
+  'node/no-unsupported-features/es-syntax': 'off',
+  semi: ['error', 'always'],
+  'space-before-function-paren': ['error', 'never']
+}
+
+module.exports = eslintConfig

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
           npm update
       - name: Lint
         run: npm run lint
+      - name: TypeScript definition linting
+        run: npm run tsd
       - name: Test
         run: npm run coverage
       - name: Codecov

--- a/package.json
+++ b/package.json
@@ -5,12 +5,16 @@
   "author": "Mark Lee",
   "license": "Apache-2.0",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "scripts": {
     "ava": "ava",
     "codecov": "nyc report --reporter=text-lcov | codecov --disable=gcov --pipe --env=CI_OS,NODE_VERSION",
     "coverage": "nyc ava",
-    "lint": "eslint .",
-    "test": "npm run lint && ava"
+    "lint": "npm run lint:js && npm run lint:ts",
+    "lint:js": "eslint .",
+    "lint:ts": "eslint --config .eslintrc.typescript.js --ext .ts .",
+    "test": "npm run lint && tsd && ava",
+    "tsd": "tsd"
   },
   "repository": "electron-userland/electron-installer-common",
   "keywords": [
@@ -19,9 +23,12 @@
   ],
   "files": [
     "NEWS.md",
-    "src"
+    "src",
+    "src/index.d.ts"
   ],
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^3.0.0",
+    "@typescript-eslint/parser": "^3.0.0",
     "ava": "^3.0.0",
     "codecov": "^3.5.0",
     "eslint": "^7.1.0",
@@ -32,7 +39,9 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
     "nyc": "^15.0.0",
-    "sinon": "^9.0.0"
+    "sinon": "^9.0.0",
+    "tsd": "^0.11.0",
+    "typescript": "^3.9.3"
   },
   "dependencies": {
     "@malept/cross-spawn-promise": "^1.0.0",
@@ -61,5 +70,11 @@
   },
   "funding": {
     "url": "https://github.com/electron-userland/electron-installer-common?sponsor=1"
+  },
+  "tsd": {
+    "directory": "test"
+  },
+  "optionalDependencies": {
+    "@types/fs-extra": "^9.0.1"
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,5 @@
 import { CopyFilterAsync, CopyFilterSync } from 'fs-extra';
+export { spawn } from '@malept/cross-spawn-promise';
 
 export type Configuration = {
   arch?: string;
@@ -20,7 +21,7 @@ export type DependencyType = 'atspi' | 'drm' | 'gbm' | 'gconf' | 'glib2' | 'gtk2
 export type DependencyMap = Record<DependencyType, string>;
 
 export type ReadMetadataOptions = {
-  logger: (msg) => void;
+  logger: (msg: any) => void;
   src: string;
 };
 
@@ -74,7 +75,6 @@ export function mergeUserSpecified(data: Record<string, unknown>, dependencyKey:
 export function readElectronVersion(appDir: string): Promise<string>;
 export function readMetadata(options: ReadMetadataOptions): Promise<PackageJSON>;
 export function replaceScopeName(name?: string, divider?: string): string;
-export function sanitizeName(name: string, allowedCharacterRange: string, replacement?: string);
-export function spawn();
+export function sanitizeName(name: string, allowedCharacterRange: string, replacement?: string): string;
 export function updateSandboxHelperPermissions(appDir: string): Promise<void>;
 export function wrapError(message: string, wrappedFunction?: () => Promise<void>): Promise<void> | ((err: Error) => void);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,80 @@
+import { CopyFilterAsync, CopyFilterSync } from 'fs-extra';
+
+export type Configuration = {
+  arch?: string;
+  bin?: string;
+  categories?: string[];
+  description?: string;
+  execArguments?: string[];
+  genericName?: string;
+  homepage?: string;
+  mimeType?: string[];
+  name?: string;
+  productDescription?: string;
+  productName?: string;
+  revision?: string;
+};
+
+export type DependencyType = 'atspi' | 'drm' | 'gbm' | 'gconf' | 'glib2' | 'gtk2' | 'gtk3' | 'gvfs' | 'kdeCliTools' | 'kdeRuntime' | 'notify' | 'nss' | 'trashCli' | 'uuid' | 'xcbDri3' | 'xss' | 'xtst' | 'xdgUtils';
+
+export type DependencyMap = Record<DependencyType, string>;
+
+export type ReadMetadataOptions = {
+  logger: (msg) => void;
+  src: string;
+};
+
+export type PackageJSON = Record<string, unknown>;
+
+export type UserSuppliedOptions = {
+  src?: string;
+  options?: Record<string, unknown>;
+} & Record<string, unknown>;
+
+export class ElectronInstaller {
+  constructor(userSupplied: UserSuppliedOptions);
+
+  readonly appIdentifier: string;
+  readonly baseAppDir: string;
+  readonly contentFunctions: string[];
+  readonly defaultDesktopTemplatePath: string;
+  readonly pixmapIconPath: string;
+  readonly sourceDir: string | undefined;
+  readonly stagingAppDir: string;
+
+  copyApplication(ignoreFunc: CopyFilterAsync | CopyFilterSync): Promise<void>;
+  copyHicolorIcons(): Promise<void>;
+  copyIcon(src: string, dest: string): Promise<void>;
+  copyLicense(copyrightFile: string): Promise<void>;
+  copyLinuxIcons(): Promise<void>;
+  copyPixmapIcon(): Promise<void>;
+  createBinarySymlink(): Promise<void>;
+  createContents(): Promise<void>;
+  createCopyright(): Promise<void>;
+  createDesktopFile(): Promise<void>;
+  createStagingDir(): Promise<void>;
+  createTemplatedFile(): Promise<void>;
+  generateOptions(): void;
+  movePackage(): Promise<void>;
+  updateSandboxHelperPermissions(): Promise<void>;
+}
+
+export function createDesktopFile(templatePath: string, dir: string, baseName: string, options: Record<string, unknown>): Promise<void>;
+export function createTemplatedFile(templatePath: string, dest: string, options: Record<string, unknown>, filePermissions?: number): Promise<void>;
+export function errorMessage(message: string, err: Error): string;
+export function generateTemplate(templatePath: string, data: Record<string, unknown>): Promise<string>;
+export function getDefaultsFromPackageJSON(pkg: PackageJSON, fallbacks?: Pick<Configuration, 'revision'>): Configuration;
+export function getDepends(version: string, dependencyMap: DependencyMap): string[];
+export function getGConfDepends(version: string, dependencyMap: DependencyMap): string[];
+export function getGTKDepends(version: string, dependencyMap: DependencyMap): string[];
+export function getTrashDepends(version: string, dependencyMap: DependencyMap): string[];
+export function getUUIDDepends(version: string, dependencyMap: DependencyMap): string[];
+export function hasSandboxHelper(appDir: string): boolean;
+export function mergeUserSpecified(data: Record<string, unknown>, dependencyKey: string, defaults: Record<string, unknown>): Record<string, unknown>;
+export function readElectronVersion(appDir: string): Promise<string>;
+export function readMetadata(options: ReadMetadataOptions): Promise<PackageJSON>;
+export function replaceScopeName(name?: string, divider?: string): string;
+export function sanitizeName(name: string, allowedCharacterRange: string, replacement?: string);
+export function spawn();
+export function updateSandboxHelperPermissions(appDir: string): Promise<void>;
+export function wrapError(message: string, wrappedFunction?: () => Promise<void>): Promise<void> | ((err: Error) => void);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -65,12 +65,16 @@ export function createDesktopFile(templatePath: string, dir: string, baseName: s
 export function createTemplatedFile(templatePath: string, dest: string, options: Record<string, unknown>, filePermissions?: number): Promise<void>;
 export function errorMessage(message: string, err: Error): string;
 export function generateTemplate(templatePath: string, data: Record<string, unknown>): Promise<string>;
+export function getATSPIDepends(version: string, dependencyMap: DependencyMap): string[];
+export function getDRMDepends(version: string, dependencyMap: DependencyMap): string[];
 export function getDefaultsFromPackageJSON(pkg: PackageJSON, fallbacks?: Pick<Configuration, 'revision'>): Configuration;
 export function getDepends(version: string, dependencyMap: DependencyMap): string[];
+export function getGBMDepends(version: string, dependencyMap: DependencyMap): string[];
 export function getGConfDepends(version: string, dependencyMap: DependencyMap): string[];
 export function getGTKDepends(version: string, dependencyMap: DependencyMap): string[];
 export function getTrashDepends(version: string, dependencyMap: DependencyMap): string[];
 export function getUUIDDepends(version: string, dependencyMap: DependencyMap): string[];
+export function getXcbDri3Depends(version: string, dependencyMap: DependencyMap): string[];
 export function hasSandboxHelper(appDir: string): boolean;
 export function mergeUserSpecified(data: Record<string, unknown>, dependencyKey: string, defaults: Record<string, unknown>): Record<string, unknown>;
 export function readElectronVersion(appDir: string): Promise<string>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -21,7 +21,8 @@ export type DependencyType = 'atspi' | 'drm' | 'gbm' | 'gconf' | 'glib2' | 'gtk2
 export type DependencyMap = Record<DependencyType, string>;
 
 export type ReadMetadataOptions = {
-  logger: (msg: any) => void;
+
+  logger: (msg: string) => void;
   src: string;
 };
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,8 @@
 import { CopyFilterAsync, CopyFilterSync } from 'fs-extra';
 export { spawn } from '@malept/cross-spawn-promise';
 
+export type CatchableFunction = (err: Error) => void;
+
 export type Configuration = {
   arch?: string;
   bin?: string;
@@ -82,4 +84,5 @@ export function readMetadata(options: ReadMetadataOptions): Promise<PackageJSON>
 export function replaceScopeName(name?: string, divider?: string): string;
 export function sanitizeName(name: string, allowedCharacterRange: string, replacement?: string): string;
 export function updateSandboxHelperPermissions(appDir: string): Promise<void>;
-export function wrapError(message: string, wrappedFunction?: () => Promise<void>): Promise<void> | ((err: Error) => void);
+export function wrapError(message: string): CatchableFunction;
+export function wrapError(message: string, wrappedFunction: () => Promise<void>): Promise<void>;

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,0 +1,4 @@
+import * as common from '..';
+
+const installer = new common.ElectronInstaller({});
+await installer.copyApplication(async() => true);

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,4 +1,74 @@
 import * as common from '..';
+import { expectType } from 'tsd';
 
 const installer = new common.ElectronInstaller({});
 await installer.copyApplication(async() => true);
+await installer.copyHicolorIcons();
+await installer.copyIcon('source.png', 'dest.png');
+await installer.copyLicense('LICENSE');
+await installer.copyLinuxIcons();
+await installer.copyPixmapIcon();
+await installer.createBinarySymlink();
+await installer.createContents();
+await installer.createCopyright();
+await installer.createDesktopFile();
+await installer.createStagingDir();
+await installer.createTemplatedFile();
+installer.generateOptions();
+await installer.movePackage();
+await installer.updateSandboxHelperPermissions();
+
+await common.createDesktopFile('template', 'dir', 'baseName', { foo: 'bar' });
+await common.createTemplatedFile('template', 'destDir', { foo: 'bar' }, 0o644);
+expectType<string>(common.errorMessage('message', new Error('test')));
+expectType<string>(await common.generateTemplate('template', { foo: 'bar' }));
+const dependencyMap: common.DependencyMap = {
+  atspi: 'libatspi',
+  drm: 'libdrm',
+  gbm: 'libgbm',
+  gconf: 'libgconf',
+  glib2: 'libglib2',
+  gtk2: 'libgtk2',
+  gtk3: 'libgtk3',
+  gvfs: 'gvfs',
+  kdeCliTools: 'kde-cli-tools',
+  kdeRuntime: 'kde-runtime',
+  notify: 'libnotify',
+  nss: 'libnss',
+  trashCli: 'trash-cli',
+  uuid: 'libuuid',
+  xcbDri3: 'libxcbdri3',
+  xss: 'libxss',
+  xtst: 'libxtst',
+  xdgUtils: 'xdg-utils'
+};
+expectType<string[]>(common.getATSPIDepends('8.0.0', dependencyMap));
+expectType<string[]>(common.getDRMDepends('8.0.0', dependencyMap));
+expectType<string[]>(common.getDepends('8.0.0', dependencyMap));
+expectType<string[]>(common.getGBMDepends('8.0.0', dependencyMap));
+expectType<string[]>(common.getGConfDepends('8.0.0', dependencyMap));
+expectType<string[]>(common.getGTKDepends('8.0.0', dependencyMap));
+expectType<string[]>(common.getTrashDepends('8.0.0', dependencyMap));
+expectType<string[]>(common.getUUIDDepends('8.0.0', dependencyMap));
+expectType<string[]>(common.getXcbDri3Depends('8.0.0', dependencyMap));
+const packageJSON = {
+  dependencies: {
+    electron: '^8.0.0'
+  }
+};
+expectType<common.Configuration>(common.getDefaultsFromPackageJSON(packageJSON));
+expectType<common.Configuration>(common.getDefaultsFromPackageJSON(packageJSON, { revision: 'revision' }));
+expectType<boolean>(common.hasSandboxHelper('appDir'));
+expectType<Record<string, unknown>>(common.mergeUserSpecified({ options: {} }, 'depends', { depends: ['a'] }));
+expectType<string>(await common.readElectronVersion('appDir'));
+expectType<common.PackageJSON>(await common.readMetadata({
+  src: 'src',
+  logger: console.log
+}));
+expectType<string>(common.replaceScopeName('@foo/bar'));
+expectType<string>(common.replaceScopeName('@foo/bar', '_'));
+expectType<string>(common.sanitizeName('@foo/bar', 'a-z'));
+expectType<string>(common.sanitizeName('@foo/bar', 'a-z', '_'));
+await common.updateSandboxHelperPermissions('appDir');
+expectType<common.CatchableFunction>(common.wrapError('message'));
+await common.wrapError('message', async() => Promise.resolve());


### PR DESCRIPTION
Needed so this module can be used in TypeScript projects (my use case for this is Electron Forge).

### TODO

* [x] extract `refactor(template):` commit to master
* [x] Make/merge a separate PR to export all of the `dependencies` exports that are necessary for other modules (i.e., `electron-installer-snap`). #72
* [x] finish tests in `test/index.test-d.ts`

After this PR, I plan on adding a separate PR to generate API docs similar to https://github.com/electron/electron-packager/pull/1131.