### PR TITLE
feat: add options.binName

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -13,6 +13,7 @@ module.exports = function getDefaultsFromPackageJSON (pkg, fallbacks = {}) {
   return {
     arch: undefined,
     bin: pkg.name || 'electron',
+    binName: pkg.name || 'electron',
     execArguments: [],
     categories: [
       'GNOME',

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,6 +6,7 @@ export type CatchableFunction = (err: Error) => void;
 export type Configuration = {
   arch?: string;
   bin?: string;
+  binName?: string;
   categories?: string[];
   description?: string;
   execArguments?: string[];

--- a/src/installer.js
+++ b/src/installer.js
@@ -144,7 +144,7 @@ class ElectronInstaller {
    */
   async createBinarySymlink () {
     const binSrc = path.join('../lib', this.appIdentifier, this.options.bin)
-    const binDest = path.join(this.stagingDir, this.baseAppDir, 'bin', this.appIdentifier)
+    const binDest = path.join(this.stagingDir, this.baseAppDir, 'bin', this.options.binName)
     debug(`Symlinking binary from ${binSrc} to ${binDest}`)
 
     const bundledBin = path.join(this.sourceDir, this.options.bin)

--- a/test/defaults.js
+++ b/test/defaults.js
@@ -7,6 +7,7 @@ test('empty package.json', t => {
   t.deepEqual(getDefaultsFromPackageJSON({}), {
     arch: undefined,
     bin: 'electron',
+    binName: 'electron',
     execArguments: [],
     categories: [
       'GNOME',

--- a/test/installer.js
+++ b/test/installer.js
@@ -88,6 +88,7 @@ test('copyLinuxIcons does nothing if icon option not specified', async t => {
 test('createBinarySymlink creates symlink when bin exists', async t => {
   const options = {
     bin: 'app-name',
+    binName: 'start_app',
     logger: log => log,
     name: 'bundled_app',
     src: path.join(__dirname, 'fixtures', 'bundled_app')
@@ -96,13 +97,14 @@ test('createBinarySymlink creates symlink when bin exists', async t => {
   installer.generateOptions()
   await installer.createStagingDir()
   await installer.createBinarySymlink()
-  const stats = await fs.lstat(path.join(installer.stagingDir, installer.baseAppDir, 'bin', 'bundled_app'))
+  const stats = await fs.lstat(path.join(installer.stagingDir, installer.baseAppDir, 'bin', 'start_app'))
   t.true(stats.isSymbolicLink())
 })
 
 test('createBinarySymlink does not create symlink when bin does not exist', async t => {
   const options = {
     bin: 'nonexistent',
+    binName: 'bundled_app',
     logger: log => log,
     name: 'bundled_app',
     src: path.join(__dirname, 'fixtures', 'bundled_app')


### PR DESCRIPTION
I've been playing with the idea of switching to using reverse DNS for the name of my apps. When using any of the installers based on this module, if I set `options.name` to a reverse-DNS name, this also affects the symlink created by it.
This might not always be the preferred behavior, so perhaps introducing a new option to set the name of the binary symlink might be a good idea. 
The new option defaults to the same values as `options.name`, so this shouldn't break anything. We will have to update `desktop.ejs` for `-debian` and `-redhat` (perhaps other modules too?) to use the new option in the `Exec=` field.

Currently, I've named it `binName` but I'm not set on the name, other ideas could be: `symlink`, `symlinkName`, or `binarySymlink`