### PR TITLE
chore: replace `asar` with `@electron/asar`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@malept/cross-spawn-promise": "^1.0.0",
-    "asar": "^3.0.0",
+    "@electron/asar": "^3.2.5",
     "debug": "^4.1.1",
     "fs-extra": "^9.0.0",
     "glob": "^7.1.4",

--- a/src/readmetadata.js
+++ b/src/readmetadata.js
@@ -2,7 +2,7 @@
 
 const { promisify } = require('util')
 
-const asar = require('asar')
+const asar = require('@electron/asar')
 const fs = require('fs-extra')
 const glob = promisify(require('glob'))
 const path = require('path')


### PR DESCRIPTION
Replaces the old `asar` npm package with `@electron/asar`, since all new versions from `3.2.1` onwards are being published to the latter.

Users of `@electron-forge/maker-deb`, `@electron-forge/maker-rpm`, and `@electron-forge/maker-snap` are currently stuck with `asar@3.2.0`, which was the latest published version of that package (and potentially have both packages installed, as Forge has already migrated to `@electron/asar` via `electron-packager`).