### PR TITLE
ci: deduplicate tests on `main` push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+*
   pull_request:
   workflow_call:
 


### PR DESCRIPTION
Fast follow-up to #196

Since we call the CI workflow from `release.yml` (which gets run on `main` push), we don't need a separate `main` push trigger for the CI workflow file itself.

https://github.com/electron-userland/electron-installer-common/blob/64210b8a48378c4b60ddfd5c9b7319c0d3e83227/.github/workflows/release.yml#L8-L10