### PR TITLE
feat: allow overriding the .desktop file basename via desktopId

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -13,6 +13,9 @@ const debug = debugModule('electron-installer-common:installer');
 export type CopyFilter = (source: string, destination: string) => boolean | Promise<boolean>;
 
 export type InstallerOptions = Configuration & {
+  /** Basename for the installed `.desktop` file (the freedesktop app ID);
+   *  defaults to the sanitized package name. */
+  desktopId?: string;
   desktopTemplate?: string;
   dest?: string;
   icon?: string | Record<string, string>;
@@ -259,7 +262,8 @@ export class ElectronInstaller {
   async createDesktopFile(): Promise<void> {
     const templatePath = this.options.desktopTemplate || this.defaultDesktopTemplatePath;
     const baseDir = path.join(this.stagingDir, this.baseAppDir, 'share', 'applications');
-    return createDesktopFile(templatePath, baseDir, this.appIdentifier, this.options);
+    const desktopBaseName = this.options.desktopId || this.appIdentifier;
+    return createDesktopFile(templatePath, baseDir, desktopBaseName, this.options);
   }
 
   /**

--- a/test/installer.spec.ts
+++ b/test/installer.spec.ts
@@ -192,6 +192,20 @@ test('createDesktopFile with custom desktopTemplate', async () => {
   );
 });
 
+test('createDesktopFile with custom desktopId', async () => {
+  const installer = new ElectronInstaller({
+    name: 'World',
+    desktopId: 'com.example.World',
+    desktopTemplate: SIMPLE_TEMPLATE_PATH,
+  });
+  installer.generateOptions();
+  await installer.createStagingDir();
+  await installer.createDesktopFile();
+  await assertPathExists(
+    path.join(installer.stagingDir, 'usr', 'share', 'applications', 'com.example.World.desktop'),
+  );
+});
+
 test('createTemplatedFile', () => {
   return unsafeTempDir(async (dir) => {
     const renderedPath = path.join(dir.path, 'rendered');


### PR DESCRIPTION
The installed .desktop file is currently always named after the sanitized package name, but the freedesktop app ID often differs - GNOME matches a window's Wayland app_id / X11 WM_CLASS against the .desktop basename, so an app whose id is e.g. com.example.App gets no launcher association when the file ships as example-app.desktop.

desktopId lets an installer name the file after the real app ID, falling back to the package name when unset.